### PR TITLE
change log location to Linux var folder

### DIFF
--- a/marketmaker/log_auto_trade.ini
+++ b/marketmaker/log_auto_trade.ini
@@ -26,7 +26,7 @@ args=(sys.stdout,)
 class=FileHandler
 level=DEBUG
 formatter=json
-args=("./logs/autotrade.json",)
+args=("/var/log/autotrade.json",)
 
 [formatter_json]
 class=pythonjsonlogger.jsonlogger.JsonFormatter

--- a/marketmaker/log_root.ini
+++ b/marketmaker/log_root.ini
@@ -26,7 +26,7 @@ args=(sys.stdout,)
 class=FileHandler
 level=DEBUG
 formatter=json
-args=("./logs/general.json",)
+args=("/var/log/general.json",)
 
 [formatter_json]
 class=pythonjsonlogger.jsonlogger.JsonFormatter


### PR DESCRIPTION
change log location to Linux var folder
obs: Is necessary change var/log permission to 
turn it writable by logger.
@suportebeloj 